### PR TITLE
Use correct path (non-cwd) to homographs.json for library

### DIFF
--- a/homograph/__init__.py
+++ b/homograph/__init__.py
@@ -1,3 +1,4 @@
 from homograph.homograph import is_homoglyph
 from homograph.homograph import is_homograph
 from homograph.homograph import homoglyphs
+from homograph.homograph import homographs

--- a/homograph/__init__.py
+++ b/homograph/__init__.py
@@ -1,3 +1,3 @@
-from homograph.homograph import homographic
-from homograph.homograph import homographs
+from homograph.homograph import is_homoglyph
+from homograph.homograph import is_homograph
 from homograph.homograph import homoglyphs

--- a/homograph/homograph.py
+++ b/homograph/homograph.py
@@ -4,7 +4,6 @@ import pathlib
 
 libdir = pathlib.Path(__file__).parent.absolute()
 hgdb_file = open(str(libdir) + '/homographs.json')
-hgdb_file = open('homographs.json')
 hgdb = json.load(hgdb_file)
 hgdb_file.close
 

--- a/homograph/homograph.py
+++ b/homograph/homograph.py
@@ -1,20 +1,21 @@
 import json
 import string
+import pathlib
 
-# The simchar data from ShamFinder could be structured
-# waaay more efficiently & less redundantly
+libdir = pathlib.Path(__file__).parent.absolute()
+hgdb_file = open(str(libdir) + '/homographs.json')
 hgdb_file = open('homographs.json')
 hgdb = json.load(hgdb_file)
 hgdb_file.close
 
 # Checks whether two individual characters are equivalent
-def homoglyphic(letter1, letter2):
+def is_homoglyph(letter1, letter2):
   if letter1 == letter2:
     return True
 
   return letter2 in [entry['char'] for entry in hgdb[letter1]['similar_char']]
 
-def homographic(domain1, domain2):
+def is_homograph(domain1, domain2):
   """
     Determine whether two domains are homographic (visually equivalent or nearly so)
   """
@@ -26,7 +27,7 @@ def homographic(domain1, domain2):
 
   for letter1, letter2 in zip(domain1, domain2):
 
-    if not homoglyphic(letter1, letter2):
+    if not is_homoglyph(letter1, letter2):
       return False
 
   return True


### PR DESCRIPTION
Currently, the library is broken, because I am using the current working directory to access homographs.json:

```python
hgdb_file = open('homographs.json')
```

This worked during initial testing because I was running the code in the same directory that the database was in. However, running the package gives me an error:

```zsh
➜  broken_package pip3 install homograph
Processing /home/max/.cache/pip/wheels/93/4b/f4/887379ec46a947d307f85b6940696b67704a96ad733a8e3987/homograph-0.1-py3-none-any.whl
Installing collected packages: homograph
Successfully installed homograph-0.1
➜  broken_package python3
Python 3.8.2 (default, Apr 27 2020, 15:53:34)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import homograph
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/max/.local/lib/python3.8/site-packages/homograph/__init__.py", line 1, in <module>
    from homograph.homograph import homographic
  File "/home/max/.local/lib/python3.8/site-packages/homograph/homograph.py", line 6, in <module>
    hgdb_file = open('homographs.json')
FileNotFoundError: [Errno 2] No such file or directory: 'homographs.json'
```

The problem is that it's looking for homographs.json in the current working directory, and not finding it. This PR fixes that by loading the DB in a way that won't break if you run the code from somewhere else.