### PR TITLE
Create MANIFEST.in so homographs.json database is included in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include homograph/homographs.json

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 setup(
   name = 'homograph',
   packages = ['homograph'],
-  version = '0.01',
+  version = '0.02',
   license='MIT',
   description = 'IDN Homograph detection tools',
   author = 'Alex Alvarado',
@@ -11,8 +11,9 @@ setup(
   # Note: The below release doesn't exist yet!
   download_url = 'https://github.com/FlowCrypt/idn-homographs-database/archive/0.02.tar.gz',
   keywords = ['IDN', 'homograph', 'attack', 'security'],
-  install_requires=[],
-  classifiers=[
+  install_requires = [],
+  include_package_data = True,
+  classifiers = [
     'Development Status :: 1 - Planning',
     'Intended Audience :: Developers',
     'Topic :: Security',


### PR DESCRIPTION
I found this out from the failing tests on the backend. This problem didn't happen when I tested on my system because of an idiosyncrasy in my Python configuration. Here is the package without the MANIFEST.in:

> ➜  dist git:(add-manifest) ✗ tar -xzvf homograph-0.02.tar.gz
> homograph-0.02/
> homograph-0.02/PKG-INFO
> homograph-0.02/homograph/
> homograph-0.02/homograph/__init__.py
> homograph-0.02/homograph/homograph.py
> homograph-0.02/setup.cfg
> homograph-0.02/setup.py

Observe that homographs.json is missing. Now, with the MANIFEST.in:

> homograph-0.02/
> homograph-0.02/PKG-INFO
> homograph-0.02/homograph/
> homograph-0.02/homograph/__init__.py
> homograph-0.02/homograph/homograph.py
> homograph-0.02/homograph/homographs.json
> homograph-0.02/setup.cfg
> homograph-0.02/setup.py

It successfully appears!
