### PR TITLE
Add note that pip install option is also available

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This is a library for detecting and generating [IDN Homographs](https://en.wikip
 
 ## Install & Use
 
-First, download the code and install dependencies:
+This code is available as a package on PyPI and can be installed via pip via `pip install homograph`.
+
+Otherwise, you can acquire the library by cloning this repository:
 
 ```shell
 git clone https://github.com/FlowCrypt/idn-homographs-database.git


### PR DESCRIPTION
This adds a note in the README explaining that cloning this code is not the only option for getting this library, as we also have a package available on PyPI.

Closes https://github.com/FlowCrypt/idn-homographs-database/issues/11